### PR TITLE
Fix some incompatabilities with current NetworkDriver API

### DIFF
--- a/napalm_aos/aos.py
+++ b/napalm_aos/aos.py
@@ -462,6 +462,7 @@ class AOSDriver(NetworkDriver):
         is_enabled = False
         speed = 0
         description = u''
+        mtu = 0  # `show interfaces` does not give a MTU
 
         command = 'show interfaces'
         output = self.device.send_command(command)
@@ -508,7 +509,8 @@ class AOSDriver(NetworkDriver):
                 'description': description,
                 'mac_address': mac_address,
                 'last_flapped': last_flapped,
-                'speed': speed
+                'speed': speed,
+                'mtu': mtu,
             }
         return interfaces
 

--- a/napalm_aos/aos.py
+++ b/napalm_aos/aos.py
@@ -1142,7 +1142,7 @@ class AOSDriver(NetworkDriver):
             }
         return snmp_dict
 
-    def get_config(self, retrieve='all'):
+    def get_config(self, retrieve='all', full=False, sanitized=False):
         """Implementation of get_config for AOS.
 
         Returns the startup or/and running configuration as dictionary.
@@ -1150,6 +1150,11 @@ class AOSDriver(NetworkDriver):
         (startup or running). Please be aware that AOS doesn't directly support candidate configuration.
         The candidate configuration is just difference between starup and running configuration,
         """
+        if full:
+            logging.warning("get_config: Got non-false value of `full`. Ignoring")
+
+        if sanitized:
+            logging.warning("get_config: Config sanitization not implemented yet!")
 
         configs = {
             'startup': u'',

--- a/napalm_aos/aos.py
+++ b/napalm_aos/aos.py
@@ -27,7 +27,6 @@ try:
     from napalm_aos.utils.AlcatelOS import *
     from napalm_aos.utils.utils import *
     from napalm.base import NetworkDriver
-    from napalm.base.utils import py23_compat
     from napalm.base.exceptions import (
         ConnectionException,
         MergeConfigException,
@@ -41,7 +40,6 @@ except ImportError:
     from napalm_aos.utils.AlcatelOS import *
     from napalm_aos.utils.utils import *
     from napalm_base import NetworkDriver
-    from napalm_base.utils import py23_compat
     from napalm_base.exceptions import (
         ConnectionException,
         MergeConfigException,
@@ -258,7 +256,7 @@ class AOSDriver(NetworkDriver):
         """Write temp file and for use with inline config and SCP."""
         tmp_dir = tempfile.gettempdir()
         if not fname:
-            fname = py23_compat.text_type(uuid.uuid4())
+            fname = str(uuid.uuid4())
         filename = os.path.join(tmp_dir, fname)
         with open(filename, 'wt') as fobj:
             fobj.write(config)
@@ -802,7 +800,7 @@ class AOSDriver(NetworkDriver):
                 'referenceid': server['Reference IP'].strip(),
                 'stratum': int(server['Stratum']),
                 'type': u'',
-                'when': py23_compat.text_type(when),
+                'when': str(when),
                 'hostpoll': int(hostpoll),
                 'reachability': int(server['Reachability'], 16),
                 'delay': float(delay),
@@ -1028,8 +1026,8 @@ class AOSDriver(NetworkDriver):
                     index] if index < len(host_matches) else ('', '')
                 results[curr_hop_idx]['probes'][index + 1] = {
                     'rtt': float(rrt),
-                    'ip_address': py23_compat.text_type(ip_address),
-                    'host_name': py23_compat.text_type(hostname)
+                    'ip_address': str(ip_address),
+                    'host_name': str(hostname)
                 }
 
         traceroute_dict['success'] = results

--- a/napalm_aos/aos.py
+++ b/napalm_aos/aos.py
@@ -1189,7 +1189,7 @@ class AOSDriver(NetworkDriver):
         startup_cfg = self.device.send_command(command)
         return format_white_space(startup_cfg)
 
-    def get_route_to(self, destination='', protocol=''):
+    def get_route_to(self, destination='', protocol='', longer=False):
         """Implementation of NAPALM method get_route_to.
 
         Returns a dict of dicts
@@ -1224,6 +1224,8 @@ class AOSDriver(NetworkDriver):
             ]
         }
         """
+        if longer:
+            logging.warning("get_route_to: Got non-false value for longer. Ignoring.")
 
         def _get_route_database(destination, route_dict):
             command = 'show ip router database dest {}'.format(destination)

--- a/napalm_aos/utils/AlcatelOS.py
+++ b/napalm_aos/utils/AlcatelOS.py
@@ -4,13 +4,11 @@ import scp
 import logging
 
 try:
-    from napalm.base.utils import py23_compat
     from napalm.base.exceptions import (
         ConnectionException,
         CommandErrorException,
     )
 except ImportError:
-    from napalm_base.utils import py23_compat
     from napalm_base.exceptions import (
         ConnectionException,
         CommandErrorException,
@@ -121,7 +119,7 @@ class AlcatelOS(object):
         if isinstance(data, int):
             data = chr(data)
         # Ensure unicode
-        return py23_compat.text_type(data)
+        return str(data)
 
     def send_command_non_blocking(self, command, timeout=60, throw_exception=True):
         logging.debug('Executing commands:\n %s' % command)

--- a/test/unit/TestAOSDriver.py
+++ b/test/unit/TestAOSDriver.py
@@ -21,7 +21,6 @@ import re
 
 from napalm_aos import aos
 from napalm.base.test.base import TestGettersNetworkDriver
-from napalm.base.utils import py23_compat
 
 
 class TestGetterAOSDriver(unittest.TestCase, TestGettersNetworkDriver):
@@ -78,7 +77,7 @@ class FakeAOSDevice:
         if self.is_printable(command):
             cmd = re.sub(r"[\[\]\;\?\/\$\*\^\+\s\|\'\:]", '_', command)
             output = self.read_txt_file('aos/mock_data/{}.txt'.format(cmd))
-        return py23_compat.text_type(output)
+        return str(output)
 
     def send_command(self, command, **kwargs):
         """Fake execute a command in the device by just returning the content of a file."""

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -5,7 +5,6 @@ import pytest
 from napalm.base.test import conftest as parent_conftest
 
 from napalm.base.test.double import BaseTestDouble
-from napalm.base.utils import py23_compat
 from napalm_aos import aos
 
 
@@ -56,7 +55,7 @@ class FakeAOSDevice(BaseTestDouble):
         filename = '{}.txt'.format(self.sanitize_text(command))
         full_path = self.find_file(filename)
         result = self.read_txt_file(full_path)
-        return py23_compat.text_type(result)
+        return str(result)
 
     def disconnect(self):
         pass

--- a/test/unit/mocked_data/test_get_interfaces/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_interfaces/normal/expected_result.json
@@ -1,483 +1,542 @@
 {
-    "2/1/13": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:d0",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/25": {
-        "speed": 10000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:52",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/5": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:c8",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/17": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:d4",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/26": {
-        "speed": 10000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:53",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/21": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:4e",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/24": {
-        "speed": 1000,
-        "description": "",
-        "is_up": true,
-        "mac_address": "e8:e7:32:ab:1f:51",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/28": {
-        "speed": 10000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:df",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/18": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:4b",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/12": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:cf",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/8": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:41",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/10": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:43",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/17": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:4a",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
     "1/1/1": {
-        "speed": 1000,
-        "description": "",
+        "is_enabled": true,
         "is_up": false,
+        "description": "",
         "mac_address": "e8:e7:32:ab:1f:3a",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/7": {
+        "last_flapped": -1,
         "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:ca",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/25": {
-        "speed": 10000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:dc",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/29": {
-        "speed": 1000,
-        "description": "",
-        "is_up": true,
-        "mac_address": "e8:e7:32:ab:1f:56",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/6": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:3f",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/4": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:3d",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/4": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:c7",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/3": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:c6",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/27": {
-        "speed": 10000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:de",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/11": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:44",
-        "last_flapped": -1.0,
-        "is_enabled": false
-    },
-    "1/1/3": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:3c",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/1": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:c4",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/8": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:cb",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/14": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:d1",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/27": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:54",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/13": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:46",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/7": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:40",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/21": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:d8",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/2": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:c5",
-        "last_flapped": -1.0,
-        "is_enabled": true
+        "mtu": 0
     },
     "1/1/2": {
-        "speed": 1000,
-        "description": "",
+        "is_enabled": true,
         "is_up": false,
+        "description": "",
         "mac_address": "e8:e7:32:ab:1f:3b",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/12": {
+        "last_flapped": -1,
         "speed": 1000,
-        "description": "",
+        "mtu": 0
+    },
+    "1/1/3": {
+        "is_enabled": true,
         "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:45",
-        "last_flapped": -1.0,
-        "is_enabled": false
-    },
-    "2/1/15": {
-        "speed": 1000,
         "description": "",
+        "mac_address": "e8:e7:32:ab:1f:3c",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/4": {
+        "is_enabled": true,
         "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:d2",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/22": {
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:3d",
+        "last_flapped": -1,
         "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:4f",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/16": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:d3",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/23": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:50",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/9": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:cc",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/19": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:4c",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/29": {
-        "speed": 1000,
-        "description": "",
-        "is_up": true,
-        "mac_address": "e8:e7:32:c4:24:e0",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/24": {
-        "speed": 1000,
-        "description": "",
-        "is_up": true,
-        "mac_address": "e8:e7:32:c4:24:db",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/20": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:4d",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/14": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:47",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/22": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:d9",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/26": {
-        "speed": 10000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:dd",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/28": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:55",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/20": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:d7",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/15": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:48",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/16": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:49",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/23": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:da",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "1/1/30": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:ab:1f:57",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/6": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:c9",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/19": {
-        "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:d6",
-        "last_flapped": -1.0,
-        "is_enabled": true
+        "mtu": 0
     },
     "1/1/5": {
-        "speed": 1000,
-        "description": "",
+        "is_enabled": true,
         "is_up": false,
+        "description": "",
         "mac_address": "e8:e7:32:ab:1f:3e",
-        "last_flapped": -1.0,
-        "is_enabled": true
-    },
-    "2/1/30": {
+        "last_flapped": -1,
         "speed": 1000,
-        "description": "",
-        "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:e1",
-        "last_flapped": -1.0,
-        "is_enabled": true
+        "mtu": 0
     },
-    "2/1/11": {
-        "speed": 1000,
-        "description": "",
+    "1/1/6": {
+        "is_enabled": true,
         "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:ce",
-        "last_flapped": -1.0,
-        "is_enabled": true
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:3f",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
     },
-    "2/1/10": {
-        "speed": 1000,
-        "description": "",
+    "1/1/7": {
+        "is_enabled": true,
         "is_up": false,
-        "mac_address": "e8:e7:32:c4:24:cd",
-        "last_flapped": -1.0,
-        "is_enabled": true
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:40",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/8": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:41",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
     },
     "1/1/9": {
-        "speed": 1000,
-        "description": "",
+        "is_enabled": true,
         "is_up": false,
+        "description": "",
         "mac_address": "e8:e7:32:ab:1f:42",
-        "last_flapped": -1.0,
-        "is_enabled": true
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/10": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:43",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/11": {
+        "is_enabled": false,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:44",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/12": {
+        "is_enabled": false,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:45",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/13": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:46",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/14": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:47",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/15": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:48",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/16": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:49",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/17": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:4a",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/18": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:4b",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/19": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:4c",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/20": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:4d",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/21": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:4e",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/22": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:4f",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/23": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:50",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/24": {
+        "is_enabled": true,
+        "is_up": true,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:51",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/25": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:52",
+        "last_flapped": -1,
+        "speed": 10000,
+        "mtu": 0
+    },
+    "1/1/26": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:53",
+        "last_flapped": -1,
+        "speed": 10000,
+        "mtu": 0
+    },
+    "1/1/27": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:54",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/28": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:55",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/29": {
+        "is_enabled": true,
+        "is_up": true,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:56",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "1/1/30": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:ab:1f:57",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/1": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:c4",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/2": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:c5",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/3": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:c6",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/4": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:c7",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/5": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:c8",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/6": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:c9",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/7": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:ca",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/8": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:cb",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/9": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:cc",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/10": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:cd",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/11": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:ce",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/12": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:cf",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/13": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:d0",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/14": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:d1",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/15": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:d2",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/16": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:d3",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/17": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:d4",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
     },
     "2/1/18": {
-        "speed": 1000,
-        "description": "",
+        "is_enabled": true,
         "is_up": true,
+        "description": "",
         "mac_address": "e8:e7:32:c4:24:d5",
-        "last_flapped": -1.0,
-        "is_enabled": true
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/19": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:d6",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/20": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:d7",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/21": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:d8",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/22": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:d9",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/23": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:da",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/24": {
+        "is_enabled": true,
+        "is_up": true,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:db",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/25": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:dc",
+        "last_flapped": -1,
+        "speed": 10000,
+        "mtu": 0
+    },
+    "2/1/26": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:dd",
+        "last_flapped": -1,
+        "speed": 10000,
+        "mtu": 0
+    },
+    "2/1/27": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:de",
+        "last_flapped": -1,
+        "speed": 10000,
+        "mtu": 0
+    },
+    "2/1/28": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:df",
+        "last_flapped": -1,
+        "speed": 10000,
+        "mtu": 0
+    },
+    "2/1/29": {
+        "is_enabled": true,
+        "is_up": true,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:e0",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
+    },
+    "2/1/30": {
+        "is_enabled": true,
+        "is_up": false,
+        "description": "",
+        "mac_address": "e8:e7:32:c4:24:e1",
+        "last_flapped": -1,
+        "speed": 1000,
+        "mtu": 0
     }
 }
-


### PR DESCRIPTION
- Remove usages of `py23_compat` due to napalm dropping py2 support
- Add `sanitized=False` to `get_config` (but don't implement sanitization, see #29)
- Add `longer=False` to `get_route_to` (but don't implement longer output, see #28)
- Add a zero `MTU` field to the `get_interfaces` interface dict.

If I understand correctly, the problem with the MTU is that it is associated to a VLAN and not an interface (at least in our `OS6860-P48`) – obtainable via `show vlan`.

These parameter stubs are nonetheless required to match the current API and not throw any `ImportError`s due to the compat access.