### PR TITLE
Remove whitespaces in vendor and os_vendor

### DIFF
--- a/napalm_aos/aos.py
+++ b/napalm_aos/aos.py
@@ -297,7 +297,7 @@ class AOSDriver(NetworkDriver):
         # Parse os version and vendor
         description = system_info['Description']
 
-        vendor, os_version = description.split(model_name)
+        vendor, os_version = description.split(" " + model_name + " ")
 
         # Parse interfaces
         interface_data = show_ip_inf.strip().splitlines()

--- a/test/unit/mocked_data/test_get_facts/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_facts/normal/expected_result.json
@@ -1,10 +1,10 @@
 {
-    "os_version": " 8.5.152.R01 Development, March 27, 2018.",
+    "os_version": "8.5.152.R01 Development, March 27, 2018.",
     "fqdn": "",
     "uptime": 0,
     "serial_number": "P468057P",
     "hostname": "0S6860",
-    "vendor": "Alcatel-Lucent Enterprise ",
+    "vendor": "Alcatel-Lucent Enterprise",
     "model": "OS6860E-24",
     "interface_list": [
         "EMP-CMMA-CHAS1",


### PR DESCRIPTION
#### Reference issues/PRs
Get_facts items contains leading and trailing whitespaces #36 

#### Fixes
Removes heading and trailing spaces from the vendor and os_version attribute used by the get_facts module.

#### Example
**output before:**
`{'vendor': 'Alcatel-Lucent Enterprise ', 'os_version': ' 8.6.289.R01 GA, July 13, 2019.'}`
**output after:**
`{'vendor': 'Alcatel-Lucent Enterprise', 'os_version': '8.6.289.R01 GA, July 13, 2019.'}`