### PR TITLE
 Remove whitespaces in vendor and os_vendor

### DIFF
--- a/napalm_aos/aos.py
+++ b/napalm_aos/aos.py
@@ -295,7 +295,7 @@ class AOSDriver(NetworkDriver):
         # Parse os version and vendor
         description = system_info['Description']
 
-        vendor, os_version = description.split(model_name)
+         vendor, os_version = description.split(" " + model_name + " ")
         vendor = vendor.strip()
         os_version = os_version.strip()
 

--- a/napalm_aos/aos.py
+++ b/napalm_aos/aos.py
@@ -295,7 +295,7 @@ class AOSDriver(NetworkDriver):
         # Parse os version and vendor
         description = system_info['Description']
 
-         vendor, os_version = description.split(" " + model_name + " ")
+        vendor, os_version = description.split(" " + model_name + " ")
         vendor = vendor.strip()
         os_version = os_version.strip()
 


### PR DESCRIPTION
**Reopend with correct username commits**

#### Reference issues/PRs
Get_facts items contains leading and trailing whitespaces #36 

#### Fixes
Removes heading and trailing spaces from the vendor and os_version attribute used by the get_facts module.

#### Example
**output before:**
`{'vendor': 'Alcatel-Lucent Enterprise ', 'os_version': ' 8.6.289.R01 GA, July 13, 2019.'}`
**output after:**
`{'vendor': 'Alcatel-Lucent Enterprise', 'os_version': '8.6.289.R01 GA, July 13, 2019.'}`